### PR TITLE
Pin pytedee_async version

### DIFF
--- a/custom_components/tedee/manifest.json
+++ b/custom_components/tedee/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/patrickhilker/tedee_hass_integration/issues",
   "dependencies": [],
   "codeowners": ["@patrickhilker"],
-  "requirements": ["pytedee-async>=0.0.9"],
+  "requirements": ["pytedee-async==0.0.9"],
   "version": "2023.6.0",
   "config_flow": true,
   "iot_class": "cloud_polling"


### PR DESCRIPTION
Hi @patrickhilker,
this is to pin the version of pytedee_async while I'm working on my next release (which will come later today) to fix some issues.
Could you move the tag "2023.6.0" to this commit, so this version is safe?