### PR TITLE
Implementing DataCoordinator and changing unlock behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ After this you should see the tedee integration on your Devices & Services page.
 
 ## Roadmap
 
-- ~~Validate personal access key during setup~~ implement reauthentication functionality in config_flow
-
 This project is open for your pull requests - just implement any feature you might need! 🚀
 
 ## Known issues

--- a/custom_components/tedee/__init__.py
+++ b/custom_components/tedee/__init__.py
@@ -3,15 +3,12 @@ import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from pytedee_async import TedeeClient, TedeeClientException, TedeeAuthException, TedeeConnectionException
-from datetime import timedelta
+from pytedee_async import TedeeClient
+from .coordinator import TedeeApiCoordinator
 
 from .const import DOMAIN, CLIENT
 
 PLATFORMS = ["lock", "sensor", "button"]
-SCAN_INTERVAL = timedelta(seconds=15)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,9 +25,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     pak = entry.data.get(CONF_ACCESS_TOKEN)
 
     tedee_client = TedeeClient(pak)
-    hass.data[DOMAIN][entry.entry_id] = tedee_client
 
-    coordinator = TedeeApiCoordinator(tedee_client)
+    hass.data[DOMAIN][entry.entry_id] = coordinator = TedeeApiCoordinator(tedee_client)
+
     await coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -51,47 +48,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        hass.data[DOMAIN].pop(CLIENT)
+        hass.data[DOMAIN].pop(entry.entry_id)
         hass.data[DOMAIN] = {}
 
     return unload_ok
-
-
-class TedeeApiCoordinator(DataUpdateCoordinator):
-
-    def __init__(self, hass, tedee_client):
-        """Initialize coordinator."""
-        super().__init__(
-            hass,
-            _LOGGER,
-            # Name of the data. For logging purposes.
-            name="tedee API coordinator",
-            # Polling interval. Will only be polled if there are subscribers.
-            update_interval=SCAN_INTERVAL,
-        )
-        self._tedee_client = tedee_client
-
-    async def _async_update_data(self):
-        try:
-            _LOGGER.debug("Update coordinator: Getting locks from API")
-            self._tedee_client.get_locks()
-        except TedeeAuthException as ex:
-            _LOGGER.error(f"Authentication failed. \
-                            Personal Key is either invalid, doesn't have the correct scopes \
-                            (Devices: Read, Locks: Operate) or is expired."
-                            )
-            return False
-            # TODO: raise ConfigEntryAuthFailed(...) from ex
-            # TODO: implement handler in config_flow 
-        except (TedeeClientException, Exception) as ex:
-            _LOGGER.error(ex)
-            raise ConfigEntryNotReady(f"Tedee failed to setup. Error: {ex}.") from ex
-
-        if not self._tedee_client.locks:
-            # No locks found; abort setup routine.
-            _LOGGER.warn("No locks found in your account")
-
-        _LOGGER.debug(f"available_locks: {self._tedee_client.locks.keys()}")
-
-        return self._tedee_client.locks
         

--- a/custom_components/tedee/__init__.py
+++ b/custom_components/tedee/__init__.py
@@ -24,7 +24,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     pak = entry.data.get(CONF_ACCESS_TOKEN)
 
-    tedee_client = TedeeClient(pak, 10)
+    tedee_client = TedeeClient(pak)
 
     hass.data[DOMAIN][entry.entry_id] = coordinator = TedeeApiCoordinator(hass, tedee_client)
 

--- a/custom_components/tedee/__init__.py
+++ b/custom_components/tedee/__init__.py
@@ -5,7 +5,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 from pytedee_async import TedeeClient
 
-from .const import CLIENT, DOMAIN
+from .const import DOMAIN
 from .coordinator import TedeeApiCoordinator
 
 PLATFORMS = ["lock", "sensor", "button"]

--- a/custom_components/tedee/__init__.py
+++ b/custom_components/tedee/__init__.py
@@ -24,9 +24,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     pak = entry.data.get(CONF_ACCESS_TOKEN)
 
-    tedee_client = TedeeClient(pak)
+    tedee_client = TedeeClient(pak, 10)
 
-    hass.data[DOMAIN][entry.entry_id] = coordinator = TedeeApiCoordinator(tedee_client)
+    hass.data[DOMAIN][entry.entry_id] = coordinator = TedeeApiCoordinator(hass, tedee_client)
 
     await coordinator.async_config_entry_first_refresh()
 

--- a/custom_components/tedee/__init__.py
+++ b/custom_components/tedee/__init__.py
@@ -4,17 +4,21 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pytedee_async import TedeeClient, TedeeClientException, TedeeAuthException, TedeeConnectionException
+from datetime import timedelta
 
 from .const import DOMAIN, CLIENT
 
 PLATFORMS = ["lock", "sensor", "button"]
+SCAN_INTERVAL = timedelta(seconds=15)
 
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass, config):
     logging.debug("Setting up Tedee integration...")
     hass.data.setdefault(DOMAIN, {})
+
     return True
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
@@ -23,28 +27,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     pak = entry.data.get(CONF_ACCESS_TOKEN)
 
-    try:
-        tedee_client = await TedeeClient.create(pak)
-    except TedeeAuthException as ex:
-        _LOGGER.error(f"Authentication failed. \
-                        Personal Key is either invalid, doesn't have the correct scopes \
-                        (Devices: Read, Locks: Operate) or is expired."
-                        )
-        return False
-        # TODO: raise ConfigEntryAuthFailed(...) from ex
-        # TODO: implement handler in config_flow 
-    except (TedeeClientException, TedeeConnectionException, Exception) as ex:
-        _LOGGER.error(ex)
-        raise ConfigEntryNotReady(f"Tedee failed to setup. Error: {ex}.") from ex
+    tedee_client = TedeeClient(pak)
+    hass.data[DOMAIN][entry.entry_id] = tedee_client
 
-    _LOGGER.debug("available_locks: %s", tedee_client.locks)
-
-    if not tedee_client.locks:
-        # No locks found; abort setup routine.
-        _LOGGER.warn("No locks found in your account")
-        return False
-    
-    hass.data[DOMAIN][CLIENT] = tedee_client
+    coordinator = TedeeApiCoordinator(tedee_client)
+    await coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
         
@@ -68,3 +55,43 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data[DOMAIN] = {}
 
     return unload_ok
+
+
+class TedeeApiCoordinator(DataUpdateCoordinator):
+
+    def __init__(self, hass, tedee_client):
+        """Initialize coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            # Name of the data. For logging purposes.
+            name="tedee API coordinator",
+            # Polling interval. Will only be polled if there are subscribers.
+            update_interval=SCAN_INTERVAL,
+        )
+        self._tedee_client = tedee_client
+
+    async def _async_update_data(self):
+        try:
+            _LOGGER.debug("Update coordinator: Getting locks from API")
+            self._tedee_client.get_locks()
+        except TedeeAuthException as ex:
+            _LOGGER.error(f"Authentication failed. \
+                            Personal Key is either invalid, doesn't have the correct scopes \
+                            (Devices: Read, Locks: Operate) or is expired."
+                            )
+            return False
+            # TODO: raise ConfigEntryAuthFailed(...) from ex
+            # TODO: implement handler in config_flow 
+        except (TedeeClientException, Exception) as ex:
+            _LOGGER.error(ex)
+            raise ConfigEntryNotReady(f"Tedee failed to setup. Error: {ex}.") from ex
+
+        if not self._tedee_client.locks:
+            # No locks found; abort setup routine.
+            _LOGGER.warn("No locks found in your account")
+
+        _LOGGER.debug(f"available_locks: {self._tedee_client.locks.keys()}")
+
+        return self._tedee_client.locks
+        

--- a/custom_components/tedee/__init__.py
+++ b/custom_components/tedee/__init__.py
@@ -4,7 +4,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from pytedee_async import TedeeClient, TedeeClientException, TedeeAuthException
+from pytedee_async import TedeeClient, TedeeClientException, TedeeAuthException, TedeeConnectionException
 
 from .const import DOMAIN, CLIENT
 
@@ -33,7 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         return False
         # TODO: raise ConfigEntryAuthFailed(...) from ex
         # TODO: implement handler in config_flow 
-    except (TedeeClientException, Exception) as ex:
+    except (TedeeClientException, TedeeConnectionException, Exception) as ex:
         _LOGGER.error(ex)
         raise ConfigEntryNotReady(f"Tedee failed to setup. Error: {ex}.") from ex
 

--- a/custom_components/tedee/__init__.py
+++ b/custom_components/tedee/__init__.py
@@ -1,12 +1,12 @@
 import logging
 
-from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.core import HomeAssistant
 from pytedee_async import TedeeClient
-from .coordinator import TedeeApiCoordinator
 
-from .const import DOMAIN, CLIENT
+from .const import CLIENT, DOMAIN
+from .coordinator import TedeeApiCoordinator
 
 PLATFORMS = ["lock", "sensor", "button"]
 

--- a/custom_components/tedee/button.py
+++ b/custom_components/tedee/button.py
@@ -1,8 +1,10 @@
 import logging
+from pytedee_async import TedeeClientException
 from homeassistant.components.button import ButtonEntity
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
 
@@ -39,4 +41,8 @@ class TedeeUnlatchButton(CoordinatorEntity, ButtonEntity):
         
 
     async def async_press(self, **kwargs) -> None:
-        await self.coordinator._tedee_client.open(self._lock.id)
+        try:
+            await self.coordinator._tedee_client.open(self._lock.id)
+        except (TedeeClientException, Exception) as ex:
+            _LOGGER.debug("Error while unlatching the door through button: %s", ex)
+            raise HomeAssistantError(ex) from ex

--- a/custom_components/tedee/button.py
+++ b/custom_components/tedee/button.py
@@ -12,7 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     
-    coordinator = hass[DOMAIN][entry.entry_id]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         [TedeeUnlatchButton(lock, coordinator) for lock in coordinator.data.values()]
     )
@@ -29,14 +29,14 @@ class TedeeUnlatchButton(CoordinatorEntity, ButtonEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._lock.id)},
             name=self._lock.name,
-            manufacturer="Tedee",
+            manufacturer="tedee",
             model=self._lock.type
         )
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._lock = self.coordinator.data[self._id]
+        self._lock = self.coordinator.data[self._lock.id]
         self.async_write_ha_state()
         
 

--- a/custom_components/tedee/button.py
+++ b/custom_components/tedee/button.py
@@ -28,8 +28,6 @@ class TedeeUnlatchButton(ButtonEntity):
             model=self._lock.type
         )
         
-    async def async_update(self):
-        self._lock = self._tedee_client.find_lock(self._lock.id)
 
     async def async_press(self, **kwargs) -> None:
         await self._tedee_client.open(self._lock.id)

--- a/custom_components/tedee/button.py
+++ b/custom_components/tedee/button.py
@@ -14,13 +14,15 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, entry, async_add_entities):
     
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
-        [TedeeUnlatchButton(lock, coordinator) for lock in coordinator.data.values()]
-    )
+    entities = []
+    entities.extend([TedeeUnlatchButton(lock, coordinator) for lock in coordinator.data.values()])
+    entities.extend([TedeeUnlockUnlatchButton(lock, coordinator) for lock in coordinator.data.values()])
+    async_add_entities(entities)
 
 class TedeeUnlatchButton(CoordinatorEntity, ButtonEntity):
-
+    """Button to only pull the spring (does not unlock if locked)"""
     def __init__(self, lock, coordinator):
+        _LOGGER.debug("Setting up ButtonEntity for %s", lock.name)
         super().__init__(coordinator)
         self._lock = lock
         self._attr_has_entity_name = True
@@ -43,7 +45,39 @@ class TedeeUnlatchButton(CoordinatorEntity, ButtonEntity):
 
     async def async_press(self, **kwargs) -> None:
         try:
-            await self.coordinator._tedee_client.open(self._lock.id)
+            await self.coordinator._tedee_client.pull(self._lock.id)
         except (TedeeClientException, Exception) as ex:
             _LOGGER.debug("Error while unlatching the door through button: %s", ex)
+            raise HomeAssistantError(ex) from ex
+        
+
+class TedeeUnlockUnlatchButton(CoordinatorEntity, ButtonEntity):
+    """Button to unlock and pull the spring / only pull the spring if unlocked"""
+    def __init__(self, lock, coordinator):
+        _LOGGER.debug("Setting up ButtonEntity for %s", lock.name)
+        super().__init__(coordinator)
+        self._lock = lock
+        self._attr_has_entity_name = True
+        self._attr_name = "Unlock & Unlatch"
+        self._attr_unique_id = f"{lock.id}-unlockunlatch-button"
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._lock.id)},
+            name=self._lock.name,
+            manufacturer="tedee",
+            model=self._lock.type
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._lock = self.coordinator.data[self._lock.id]
+        self.async_write_ha_state()
+        
+
+    async def async_press(self, **kwargs) -> None:
+        try:
+            await self.coordinator._tedee_client.open(self._lock.id)
+        except (TedeeClientException, Exception) as ex:
+            _LOGGER.debug("Error while opening the door through button: %s", ex)
             raise HomeAssistantError(ex) from ex

--- a/custom_components/tedee/button.py
+++ b/custom_components/tedee/button.py
@@ -1,10 +1,11 @@
 import logging
-from pytedee_async import TedeeClientException
+
 from homeassistant.components.button import ButtonEntity
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.core import callback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from pytedee_async import TedeeClientException
 
 from .const import DOMAIN
 

--- a/custom_components/tedee/config_flow.py
+++ b/custom_components/tedee/config_flow.py
@@ -63,13 +63,10 @@ class TedeeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data_schema=PERSONAL_KEY_SCHEMA,
             )
         self.hass.config_entries.async_update_entry(
-                    self.reauth_entry, data=user_input
-                )   
+                self.reauth_entry, data=user_input
+            )   
         await self.hass.config_entries.async_reload(self.reauth_entry.entry_id)
-        return self.async_create_entry(
-                    title="",
-                    data={}
-                )
+        return self.async_abort(reason="reauth_successful")
     
     
 class OptionsFlowHandler(config_entries.OptionsFlow):

--- a/custom_components/tedee/config_flow.py
+++ b/custom_components/tedee/config_flow.py
@@ -1,16 +1,13 @@
-import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
-from homeassistant import config_entries
-from homeassistant.core import callback
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ACCESS_TOKEN
-
 from typing import Any, Dict
 
-from .const import (
-    DOMAIN,
-    NAME,
-)
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.core import callback
+
+from .const import DOMAIN, NAME
 
 PERSONAL_KEY_SCHEMA = vol.Schema({vol.Required(CONF_ACCESS_TOKEN): cv.string})
 

--- a/custom_components/tedee/config_flow.py
+++ b/custom_components/tedee/config_flow.py
@@ -2,7 +2,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant import config_entries
 from homeassistant.core import callback
-
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN
 
 from typing import Any, Dict
@@ -12,10 +12,14 @@ from .const import (
     NAME,
 )
 
+PERSONAL_KEY_SCHEMA = vol.Schema({vol.Required(CONF_ACCESS_TOKEN): cv.string})
+
 class TedeeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    reauth_entry: ConfigEntry = None
     
     def __init__(self):
         self._errors = {}
@@ -28,19 +32,44 @@ class TedeeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(
                     title=NAME, 
                     data=user_input
+                    
                 )
         
         return self.async_show_form(
-            step_id="user", data_schema=vol.Schema({vol.Required(CONF_ACCESS_TOKEN): cv.string})
+            step_id="user", data_schema=PERSONAL_KEY_SCHEMA
         )
     
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: config_entries.ConfigEntry,
+        config_entry: ConfigEntry,
     ) -> config_entries.OptionsFlow:
         """Create the options flow."""
         return OptionsFlowHandler(config_entry)
+    
+    
+    async def async_step_reauth(self, user_input=None):
+        """Perform reauth upon an API authentication error."""
+        self.reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None):
+        """Dialog that informs the user that reauth is required."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=PERSONAL_KEY_SCHEMA,
+            )
+        self.hass.config_entries.async_update_entry(
+                    self.reauth_entry, data=user_input
+                )   
+        await self.hass.config_entries.async_reload(self.reauth_entry.entry_id)
+        return self.async_create_entry(
+                    title="",
+                    data={}
+                )
     
     
 class OptionsFlowHandler(config_entries.OptionsFlow):
@@ -66,11 +95,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     data={}
                 )
 
-        options_schema = vol.Schema(
-            {
-                vol.Required(CONF_ACCESS_TOKEN): cv.string
-            }
-        )
+        options_schema = PERSONAL_KEY_SCHEMA
 
         return self.async_show_form(
             step_id="init", data_schema=options_schema, errors=errors

--- a/custom_components/tedee/const.py
+++ b/custom_components/tedee/const.py
@@ -4,5 +4,3 @@ DOMAIN = "tedee"
 NAME = "Tedee"
 
 SCAN_INTERVAL = timedelta(seconds=10)
-
-CLIENT = "client"

--- a/custom_components/tedee/coordinator.py
+++ b/custom_components/tedee/coordinator.py
@@ -36,13 +36,12 @@ class TedeeApiCoordinator(DataUpdateCoordinator):
             raise ConfigEntryAuthFailed(msg) from ex
         except (TedeeClientException, Exception) as ex:
             _LOGGER.error(ex)
-            #raise ConfigEntryNotReady(f"Tedee failed to setup. Error: {ex}.") from ex
             raise UpdateFailed("Querying API failed. Error: %s", ex)
         
         if not self._tedee_client.locks_dict:
             # No locks found; abort setup routine.
             _LOGGER.warn("No locks found in your account.")
 
-        _LOGGER.debug("available_locks: %s", ",".join(self._tedee_client.locks_dict.keys()))
+        _LOGGER.debug("available_locks: %s", ", ".join(map(str, self._tedee_client.locks_dict.keys())))
 
         return self._tedee_client.locks_dict

--- a/custom_components/tedee/coordinator.py
+++ b/custom_components/tedee/coordinator.py
@@ -1,0 +1,50 @@
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from pytedee_async import TedeeClientException, TedeeAuthException
+import logging
+from datetime import timedelta
+
+SCAN_INTERVAL = timedelta(seconds=15)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+
+class TedeeApiCoordinator(DataUpdateCoordinator):
+
+    def __init__(self, hass, tedee_client):
+        """Initialize coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            # Name of the data. For logging purposes.
+            name="tedee API coordinator",
+            # Polling interval. Will only be polled if there are subscribers.
+            update_interval=SCAN_INTERVAL,
+        )
+        self._tedee_client = tedee_client
+
+    async def _async_update_data(self):
+        try:
+            _LOGGER.debug("Update coordinator: Getting locks from API")
+            self._tedee_client.get_locks()
+        except TedeeAuthException as ex:
+            _LOGGER.error(f"Authentication failed. \
+                            Personal Key is either invalid, doesn't have the correct scopes \
+                            (Devices: Read, Locks: Operate) or is expired."
+                            )
+            return False
+            # TODO: raise ConfigEntryAuthFailed(...) from ex
+            # TODO: implement handler in config_flow 
+        except (TedeeClientException, Exception) as ex:
+            _LOGGER.error(ex)
+            #raise ConfigEntryNotReady(f"Tedee failed to setup. Error: {ex}.") from ex
+            raise UpdateFailed(f"Querying API failed. Error: {ex}")
+
+        if not self._tedee_client.locks:
+            # No locks found; abort setup routine.
+            _LOGGER.warn("No locks found in your account")
+
+        _LOGGER.debug(f"available_locks: {self._tedee_client.locks.keys()}")
+
+        return self._tedee_client.locks

--- a/custom_components/tedee/coordinator.py
+++ b/custom_components/tedee/coordinator.py
@@ -1,8 +1,10 @@
-from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from pytedee_async import TedeeClientException, TedeeAuthException
 import logging
 from datetime import timedelta
+
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import (DataUpdateCoordinator,
+                                                      UpdateFailed)
+from pytedee_async import TedeeAuthException, TedeeClientException
 
 SCAN_INTERVAL = timedelta(seconds=15)
 

--- a/custom_components/tedee/coordinator.py
+++ b/custom_components/tedee/coordinator.py
@@ -27,7 +27,7 @@ class TedeeApiCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         try:
             _LOGGER.debug("Update coordinator: Getting locks from API")
-            self._tedee_client.get_locks()
+            await self._tedee_client.get_locks()
         except TedeeAuthException as ex:
             msg = "Authentication failed. \
                             Personal Key is either invalid, doesn't have the correct scopes \
@@ -38,11 +38,11 @@ class TedeeApiCoordinator(DataUpdateCoordinator):
             _LOGGER.error(ex)
             #raise ConfigEntryNotReady(f"Tedee failed to setup. Error: {ex}.") from ex
             raise UpdateFailed("Querying API failed. Error: %s", ex)
-
+        
         if not self._tedee_client.locks_dict:
             # No locks found; abort setup routine.
-            _LOGGER.warn("No locks found in your account")
+            _LOGGER.warn("No locks found in your account.")
 
-        _LOGGER.debug("available_locks: %s", self._tedee_client.locks_dict.keys())
+        _LOGGER.debug("available_locks: %s", ",".join(self._tedee_client.locks_dict.keys()))
 
         return self._tedee_client.locks_dict

--- a/custom_components/tedee/coordinator.py
+++ b/custom_components/tedee/coordinator.py
@@ -13,6 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class TedeeApiCoordinator(DataUpdateCoordinator):
+    """Class to handle fetching data from the tedee API centrally"""
 
     def __init__(self, hass, tedee_client):
         """Initialize coordinator."""

--- a/custom_components/tedee/coordinator.py
+++ b/custom_components/tedee/coordinator.py
@@ -29,22 +29,20 @@ class TedeeApiCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("Update coordinator: Getting locks from API")
             self._tedee_client.get_locks()
         except TedeeAuthException as ex:
-            _LOGGER.error(f"Authentication failed. \
+            msg = "Authentication failed. \
                             Personal Key is either invalid, doesn't have the correct scopes \
                             (Devices: Read, Locks: Operate) or is expired."
-                            )
-            return False
-            # TODO: raise ConfigEntryAuthFailed(...) from ex
-            # TODO: implement handler in config_flow 
+            _LOGGER.error(msg)
+            raise ConfigEntryAuthFailed(msg) from ex
         except (TedeeClientException, Exception) as ex:
             _LOGGER.error(ex)
             #raise ConfigEntryNotReady(f"Tedee failed to setup. Error: {ex}.") from ex
-            raise UpdateFailed(f"Querying API failed. Error: {ex}")
+            raise UpdateFailed("Querying API failed. Error: %s", ex)
 
-        if not self._tedee_client.locks:
+        if not self._tedee_client.locks_dict:
             # No locks found; abort setup routine.
             _LOGGER.warn("No locks found in your account")
 
-        _LOGGER.debug(f"available_locks: {self._tedee_client.locks.keys()}")
+        _LOGGER.debug("available_locks: %s", self._tedee_client.locks_dict.keys())
 
-        return self._tedee_client.locks
+        return self._tedee_client.locks_dict

--- a/custom_components/tedee/lock.py
+++ b/custom_components/tedee/lock.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     
-    coordinator = hass[DOMAIN][entry.entry_id]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         [TedeeLock(lock, coordinator) for lock in coordinator.data.values()]
     )
@@ -40,7 +40,7 @@ class TedeeLock(CoordinatorEntity, LockEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._lock.id)},
             name=self._lock.name,
-            manufacturer="Tedee",
+            manufacturer="tedee",
             model=self._lock.type
         )
 
@@ -50,19 +50,21 @@ class TedeeLock(CoordinatorEntity, LockEntity):
 
     @property
     def is_locked(self) -> bool:
-        return self._state == 6
+        '''Get state directly from coordinator for quickest state update'''
+        return self.coordinator._tedee_client.locks_dict[self._lock._id]._state == 6
 
     @property
     def is_unlocking(self) -> bool:
-        return self._state == 4
-
+        return self.coordinator._tedee_client.locks_dict[self._lock._id]._state == 4
+    
     @property
     def is_locking(self) -> bool:
-        return self._state == 5
+        return self.coordinator._tedee_client.locks_dict[self._lock._id]._state == 5
     
     @property
     def is_jammed(self) -> bool:
-        return self._state == 3
+        return self.coordinator._tedee_client.locks_dict[self._lock._id]._state == 3
+
 
     @property
     def extra_state_attributes(self):
@@ -79,7 +81,7 @@ class TedeeLock(CoordinatorEntity, LockEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._lock = self.coordinator.data[self._id]
+        self._lock = self.coordinator.data[self._lock.id]
         self.async_write_ha_state()
 
         

--- a/custom_components/tedee/lock.py
+++ b/custom_components/tedee/lock.py
@@ -28,8 +28,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class TedeeLock(CoordinatorEntity, LockEntity):
 
     def __init__(self, lock, coordinator):
+        _LOGGER.debug("Setting up LockEntity for %s", lock.name)
         super().__init__(coordinator)
-        _LOGGER.debug("LockEntity: %s", lock.name)
         
         self._lock = lock
         self._id = self._lock.id
@@ -51,20 +51,19 @@ class TedeeLock(CoordinatorEntity, LockEntity):
 
     @property
     def is_locked(self) -> bool:
-        '''Get state directly from coordinator for quickest state update'''
-        return self.coordinator._tedee_client.locks_dict[self._lock._id]._state == 6
+        return self._lock.state == 6
 
     @property
     def is_unlocking(self) -> bool:
-        return self.coordinator._tedee_client.locks_dict[self._lock._id]._state == 4
+        return self._lock.state == 4
     
     @property
     def is_locking(self) -> bool:
-        return self.coordinator._tedee_client.locks_dict[self._lock._id]._state == 5
+        return self._lock.state == 5
     
     @property
     def is_jammed(self) -> bool:
-        return self.coordinator._tedee_client.locks_dict[self._lock._id]._state == 3
+        return self._lock.state == 3
 
 
     @property
@@ -88,6 +87,7 @@ class TedeeLock(CoordinatorEntity, LockEntity):
         
     async def async_unlock(self, **kwargs):
         try:
+            self._lock.state = 4
             await self.coordinator._tedee_client.unlock(self._id)
             await self.coordinator.async_request_refresh()
         except (TedeeClientException, Exception) as ex:
@@ -96,6 +96,7 @@ class TedeeLock(CoordinatorEntity, LockEntity):
 
     async def async_lock(self, **kwargs):
         try:
+            self._lock.state = 5
             await self.coordinator._tedee_client.lock(self._id)
             await self.coordinator.async_request_refresh()
         except (TedeeClientException, Exception) as ex:
@@ -104,6 +105,7 @@ class TedeeLock(CoordinatorEntity, LockEntity):
 
     async def async_open(self, **kwargs):
         try:
+            self._lock.state = 4
             await self.coordinator._tedee_client.open(self._id)
             await self.coordinator.async_request_refresh()
         except (TedeeClientException, Exception) as ex:

--- a/custom_components/tedee/lock.py
+++ b/custom_components/tedee/lock.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pytedee_async import TedeeClientException
 
-from .const import CLIENT, DOMAIN
+from .const import DOMAIN
 
 ATTR_NUMERIC_STATE = "numeric_state"
 ATTR_SUPPORT_PULLSPING = "support_pullspring"

--- a/custom_components/tedee/lock.py
+++ b/custom_components/tedee/lock.py
@@ -5,6 +5,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_ID, ATTR_BATTERY_CHARGING
 from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN, CLIENT
 
@@ -85,17 +86,23 @@ class TedeeLock(CoordinatorEntity, LockEntity):
     async def async_unlock(self, **kwargs):
         try:
             await self.coordinator._tedee_client.unlock(self._id)
-        except TedeeClientException:
-            _LOGGER.debug("Failed to unlock the door.")
+            await self.coordinator.async_request_refresh()
+        except (TedeeClientException, Exception) as ex:
+            _LOGGER.debug("Failed to unlock the door. Lock %s", self._id)
+            raise HomeAssistantError(ex) from ex
 
     async def async_lock(self, **kwargs):
         try:
             await self.coordinator._tedee_client.lock(self._id)
-        except TedeeClientException:
-            _LOGGER.debug("Failed to lock the door.")
+            await self.coordinator.async_request_refresh()
+        except (TedeeClientException, Exception) as ex:
+            _LOGGER.debug("Failed to lock the door. Lock %s", self._id)
+            raise HomeAssistantError(ex) from ex
 
     async def async_open(self, **kwargs):
         try:
             await self.coordinator._tedee_client.open(self._id)
-        except TedeeClientException:
-            _LOGGER.debug("Failed to unlatch the door.")        
+            await self.coordinator.async_request_refresh()
+        except (TedeeClientException, Exception) as ex:
+            _LOGGER.debug("Failed to unlatch the door. Lock %s", self._id)     
+            raise HomeAssistantError(ex) from ex   

--- a/custom_components/tedee/lock.py
+++ b/custom_components/tedee/lock.py
@@ -47,10 +47,6 @@ class TedeeLock(LockEntity):
         return SUPPORT_OPEN
 
     @property
-    def available(self) -> bool:
-        return self._available
-
-    @property
     def is_locked(self) -> bool:
         return self._state == 6
 
@@ -77,26 +73,6 @@ class TedeeLock(LockEntity):
             ATTR_SUPPORT_PULLSPING: self._lock.is_enabled_pullspring,
             ATTR_DURATION_PULLSPRING: self._lock.duration_pullspring,
         }
-
-    async def async_update(self):
-        try:
-            self._available = await self._client.update(self._id)
-        except TedeeAuthException as ex:
-            msg = "Credentials invalid. Probably your token expired. Update in integration settings."
-            _LOGGER.error(msg)
-            raise HomeAssistantError(msg)
-        except TedeeConnectionException as ex:
-            msg = "Problem while establish connection to the API. Maybe you're offline. Try again later."
-            _LOGGER.warn(msg)
-            raise HomeAssistantError(msg)
-        except TedeeClientException as ex:
-            msg = f"Internal error occured with Tedee integration, please report to developers. Original Error: {msg}"
-            _LOGGER.error(msg)
-            raise HomeAssistantError(msg)
-
-        self._lock = self._client.find_lock(self._id)
-        self._id = self._lock.id
-        self._state = self._lock.state
 
         
     async def async_unlock(self, **kwargs):

--- a/custom_components/tedee/lock.py
+++ b/custom_components/tedee/lock.py
@@ -1,14 +1,15 @@
 import logging
-from pytedee_async import TedeeClientException
+
 from homeassistant.components.lock import SUPPORT_OPEN, LockEntity
-from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_ID, ATTR_BATTERY_CHARGING
+from homeassistant.const import (ATTR_BATTERY_CHARGING, ATTR_BATTERY_LEVEL,
+                                 ATTR_ID)
 from homeassistant.core import callback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from pytedee_async import TedeeClientException
 
-from .const import DOMAIN, CLIENT
-
+from .const import CLIENT, DOMAIN
 
 ATTR_NUMERIC_STATE = "numeric_state"
 ATTR_SUPPORT_PULLSPING = "support_pullspring"

--- a/custom_components/tedee/manifest.json
+++ b/custom_components/tedee/manifest.json
@@ -5,8 +5,8 @@
   "issue_tracker": "https://github.com/patrickhilker/tedee_hass_integration/issues",
   "dependencies": [],
   "codeowners": ["@patrickhilker"],
-  "requirements": ["pytedee-async>=0.0.9"],
-  "version": "2023.6.0",
+  "requirements": ["pytedee-async>=0.0.10"],
+  "version": "2023.6.1",
   "config_flow": true,
   "iot_class": "cloud_polling"
 }

--- a/custom_components/tedee/manifest.json
+++ b/custom_components/tedee/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/patrickhilker/tedee_hass_integration/issues",
   "dependencies": [],
   "codeowners": ["@patrickhilker"],
-  "requirements": ["pytedee-async==0.1.0"],
+  "requirements": ["pytedee-async==0.1.1"],
   "version": "2023.7.0",
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/custom_components/tedee/manifest.json
+++ b/custom_components/tedee/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/patrickhilker/tedee_hass_integration/issues",
   "dependencies": [],
   "codeowners": ["@patrickhilker"],
-  "requirements": ["pytedee-async>=0.0.11"],
+  "requirements": ["pytedee-async==0.0.12"],
   "version": "2023.6.1",
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/custom_components/tedee/manifest.json
+++ b/custom_components/tedee/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/patrickhilker/tedee_hass_integration/issues",
   "dependencies": [],
   "codeowners": ["@patrickhilker"],
-  "requirements": ["pytedee-async>=0.0.10"],
+  "requirements": ["pytedee-async>=0.0.11"],
   "version": "2023.6.1",
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/custom_components/tedee/manifest.json
+++ b/custom_components/tedee/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "tedee",
-  "name": "Tedee",
+  "name": "tedee",
   "documentation": "https://github.com/patrickhilker/tedee_hass_integration",
   "issue_tracker": "https://github.com/patrickhilker/tedee_hass_integration/issues",
   "dependencies": [],
   "codeowners": ["@patrickhilker"],
-  "requirements": ["pytedee-async==0.0.12"],
-  "version": "2023.6.1",
+  "requirements": ["pytedee-async==0.1.0"],
+  "version": "2023.7.0",
   "config_flow": true,
   "iot_class": "cloud_polling"
 }

--- a/custom_components/tedee/sensor.py
+++ b/custom_components/tedee/sensor.py
@@ -4,7 +4,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CLIENT, DOMAIN
+from .const import DOMAIN
 
 
 async def async_setup_entry(hass, entry, async_add_entities):

--- a/custom_components/tedee/sensor.py
+++ b/custom_components/tedee/sensor.py
@@ -1,3 +1,5 @@
+import logging
+
 from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
                                              SensorStateClass)
 from homeassistant.core import callback
@@ -6,6 +8,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 
+_LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     
@@ -18,6 +21,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class TedeeBatterySensor(CoordinatorEntity, SensorEntity):
 
     def __init__(self, lock, coordinator):
+        _LOGGER.debug("Setting up SensorEntity for %s", lock.name)
         super().__init__(coordinator)
         self._lock = lock
         self._attr_device_class = SensorDeviceClass.BATTERY

--- a/custom_components/tedee/sensor.py
+++ b/custom_components/tedee/sensor.py
@@ -1,8 +1,11 @@
-from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
+                                             SensorStateClass)
 from homeassistant.core import callback
-from .const import DOMAIN, CLIENT
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CLIENT, DOMAIN
+
 
 async def async_setup_entry(hass, entry, async_add_entities):
     

--- a/custom_components/tedee/sensor.py
+++ b/custom_components/tedee/sensor.py
@@ -26,8 +26,6 @@ class TedeeBatterySensor(SensorEntity):
             model=self._lock.type
         )
 
-    async def async_update(self):
-        self._lock = self._tedee_client.find_lock(self._lock.id)
 
     @property
     def native_value(self):

--- a/custom_components/tedee/sensor.py
+++ b/custom_components/tedee/sensor.py
@@ -6,7 +6,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 async def async_setup_entry(hass, entry, async_add_entities):
     
-    coordinator = hass[DOMAIN][entry.entry_id]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities(
         [TedeeBatterySensor(lock, coordinator) for lock in coordinator.data.values()]
@@ -26,14 +26,14 @@ class TedeeBatterySensor(CoordinatorEntity, SensorEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._lock.id)},
             name=self._lock.name,
-            manufacturer="Tedee",
+            manufacturer="tedee",
             model=self._lock.type
         )
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._lock = self.coordinator.data[self._id]
+        self._lock = self.coordinator.data[self._lock.id]
         self.async_write_ha_state()
 
     @property

--- a/custom_components/tedee/translations/de.json
+++ b/custom_components/tedee/translations/de.json
@@ -8,7 +8,17 @@
                 "data": {
                     "access_token": "Personal Access Key"
                 }
+            },
+            "reauth_confirm": {
+                "title": "Der Personal Access Key muss erneuert werden",
+                "description": "tedee benötigt einen aktualisierten Personal Access Key, weil der bisherige ungültig geworden ist, oder abgelaufen ist..",
+                "data": {
+                    "access_token": "Personal Access Key"
+                }
             }
+        },
+        "abort": {
+            "reauth_successful": "Personal Access Key erfolgreich erneuert!"
         },
         "error": {
             "auth": "Etwas hat nicht geklappt."

--- a/custom_components/tedee/translations/en.json
+++ b/custom_components/tedee/translations/en.json
@@ -8,7 +8,17 @@
                 "data": {
                     "access_token": "Personal Access Key"
                 }
+            },
+            "reauth_confirm": {
+                "title": "Update of Personal Access Key required",
+                "description": "tedee needs an updated Personal Access Key, because the existing one is invalid or might have expired.",
+                "data": {
+                    "access_token": "Personal Access Key"
+                }
             }
+        },
+        "abort": {
+            "reauth_successful": "Personal Access Key renewed successfully!"
         },
         "error": {
             "auth": "Something went wrong."


### PR DESCRIPTION
## For dev only
@patrickhilker Do not merge before addressing #13 
- building on data coordinator to get state updates for all locks with a single API call and hopefully address #10 
- changing the unlock and open behaviors (see below for details) to address #8 and #12 
- sorting the packages with isort

## Release notes
- **CHANGED:** unlocking the lock (as well as service.unlock) now only unlocks the lock without pulling the latch
- **CHANGED:** service.open now unlocks the lock and pulls the latch if the lock is locked and pulls the latch if it is unlocked
- added a separate "Unlock & Unlatch" button to trigger the above mentioned behavior, the "Unlatch" button will only pull the latch if the door is already unlocked
- implemented re-authentication in case the token is revoked or expires
- bug fix to avoid flooding the API for people with multiple locks
